### PR TITLE
test: raise translation and server coverage

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock heavy dependencies before importing buildServer
+const mockGenerate = vi.hoisted(() =>
+  vi.fn(async () => ({ data: [{ url: 'https://img.test/mock.png' }] }))
+);
+
 vi.mock('@clerk/fastify', () => ({
   clerkPlugin: async () => {},
   getAuth: vi.fn(() => ({ userId: 'u1' })),
@@ -8,7 +12,7 @@ vi.mock('@clerk/fastify', () => ({
 vi.mock('openai', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const MockOpenAI = function(this: any) {
-    this.images = { generate: vi.fn(async () => ({ data: [{ url: 'https://img.test/mock.png' }] })) };
+    this.images = { generate: mockGenerate };
   };
   return { default: MockOpenAI };
 });
@@ -16,6 +20,11 @@ vi.mock('openai', () => {
 import { buildServer } from './index.js';
 
 describe('buildServer()', () => {
+  beforeEach(() => {
+    mockGenerate.mockReset();
+    mockGenerate.mockResolvedValue({ data: [{ url: 'https://img.test/mock.png' }] });
+  });
+
   it('GET /health returns {status: ok}', async () => {
     const app = await buildServer();
     const res = await app.inject({ method: 'GET', url: '/health' });
@@ -52,6 +61,86 @@ describe('buildServer()', () => {
       payload: { mood: 'happy' },
     });
     expect(fakeConn.write).toHaveBeenCalledWith(expect.stringContaining('generation-started'));
+  });
+
+  it('removes SSE connections that fail while sending the start event', async () => {
+    const app = await buildServer();
+    const flakyConn = {
+      write: vi.fn(() => {
+        throw new Error('socket closed');
+      }),
+      end: vi.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (app as any).sseConnections.add(flakyConn);
+    await app.inject({
+      method: 'POST',
+      url: '/webhook/elevenlabs/story-illustration',
+      payload: { mood: 'happy' },
+    });
+
+    expect(flakyConn.write).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((app as any).sseConnections.has(flakyConn)).toBe(false);
+  });
+
+  it('removes SSE connections that fail while sending the final illustration event', async () => {
+    const app = await buildServer();
+    const flakyConn = {
+      write: vi.fn()
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('socket closed');
+        }),
+      end: vi.fn(),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (app as any).sseConnections.add(flakyConn);
+    await app.inject({
+      method: 'POST',
+      url: '/webhook/elevenlabs/story-illustration',
+      payload: { mood: 'happy' },
+    });
+
+    expect(flakyConn.write).toHaveBeenCalledTimes(2);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((app as any).sseConnections.has(flakyConn)).toBe(false);
+  });
+
+  it('returns a 500 when OpenAI does not return an image url', async () => {
+    mockGenerate.mockResolvedValueOnce({ data: [{} as { url: string }] });
+    const app = await buildServer();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhook/elevenlabs/story-illustration',
+      payload: { story_content: 'a tale' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toMatchObject({
+      success: false,
+      error: 'No image URL returned from OpenAI',
+    });
+  });
+
+  it('returns a 500 when image generation throws', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('service unavailable'));
+    const app = await buildServer();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhook/elevenlabs/story-illustration',
+      payload: { story_content: 'a tale' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toMatchObject({
+      success: false,
+      error: 'service unavailable',
+    });
   });
 
   it('validateEnv throws when PORT is missing', async () => {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,42 +5,32 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
   // Get current user info
   fastify.get('/user', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // You would typically fetch user data from your database here
-      // For now, we'll return basic info from Clerk
-      return {
-        id: userId,
-        // Additional user data would be fetched from your database
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // You would typically fetch user data from your database here
+    // For now, we'll return basic info from Clerk
+    return {
+      id: userId,
+      // Additional user data would be fetched from your database
+    };
   });
-  
+
   // Get user role
   fastify.get('/role', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // In a real app, you would fetch the user's role from your database
-      // For demo purposes, we'll return a default role
-      return {
-        role: 'teacher',
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would fetch the user's role from your database
+    // For demo purposes, we'll return a default role
+    return {
+      role: 'teacher',
+    };
   });
 };
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -15,68 +15,63 @@ const notificationsRoutes: FastifyPluginAsync = async (fastify) => {
   // Get all notifications for the current user
   fastify.get('/', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // In a real app, you would fetch from your database
-      const notifications: Notification[] = [
-        {
-          id: '1',
-          title: 'System Maintenance',
-          message: 'The platform will be undergoing maintenance tonight from 2:00 AM to 4:00 AM.',
-          timestamp: '2023-05-15T14:30:00Z',
-          type: 'info',
-          read: false,
-          userId
-        },
-        {
-          id: '2',
-          title: 'New Message Received',
-          message: 'You have received a new message from Principal Johnson regarding the upcoming staff meeting.',
-          timestamp: '2023-05-15T10:15:00Z',
-          type: 'info',
-          read: true,
-          userId
-        },
-        {
-          id: '3',
-          title: 'Transportation Alert',
-          message: 'Bus #103 will be running 15 minutes late today due to road construction.',
-          timestamp: '2023-05-15T08:20:00Z',
-          type: 'warning',
-          read: false,
-          userId
-        },
-        {
-          id: '4',
-          title: 'Successful Registration',
-          message: 'Student Emily Johnson has been successfully registered for the summer language program.',
-          timestamp: '2023-05-14T16:45:00Z',
-          type: 'success',
-          read: true,
-          userId
-        },
-        {
-          id: '5',
-          title: 'Emergency Drill',
-          message: 'Reminder: Fire drill scheduled for tomorrow at 10:30 AM. Please review safety procedures.',
-          timestamp: '2023-05-14T11:10:00Z',
-          type: 'error',
-          read: false,
-          userId
-        }
-      ];
-      
-      return notifications;
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would fetch from your database
+    const notifications: Notification[] = [
+      {
+        id: '1',
+        title: 'System Maintenance',
+        message: 'The platform will be undergoing maintenance tonight from 2:00 AM to 4:00 AM.',
+        timestamp: '2023-05-15T14:30:00Z',
+        type: 'info',
+        read: false,
+        userId
+      },
+      {
+        id: '2',
+        title: 'New Message Received',
+        message: 'You have received a new message from Principal Johnson regarding the upcoming staff meeting.',
+        timestamp: '2023-05-15T10:15:00Z',
+        type: 'info',
+        read: true,
+        userId
+      },
+      {
+        id: '3',
+        title: 'Transportation Alert',
+        message: 'Bus #103 will be running 15 minutes late today due to road construction.',
+        timestamp: '2023-05-15T08:20:00Z',
+        type: 'warning',
+        read: false,
+        userId
+      },
+      {
+        id: '4',
+        title: 'Successful Registration',
+        message: 'Student Emily Johnson has been successfully registered for the summer language program.',
+        timestamp: '2023-05-14T16:45:00Z',
+        type: 'success',
+        read: true,
+        userId
+      },
+      {
+        id: '5',
+        title: 'Emergency Drill',
+        message: 'Reminder: Fire drill scheduled for tomorrow at 10:30 AM. Please review safety procedures.',
+        timestamp: '2023-05-14T11:10:00Z',
+        type: 'error',
+        read: false,
+        userId
+      }
+    ];
+
+    return notifications;
   });
-  
+
   // Mark a notification as read
   fastify.patch('/:id/read', async (request, reply) => {
     const { userId } = getAuth(request);
@@ -84,39 +79,29 @@ const notificationsRoutes: FastifyPluginAsync = async (fastify) => {
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // In a real app, you would update your database
-      return {
-        success: true,
-        message: 'Notification marked as read'
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would update your database
+    return {
+      success: true,
+      message: 'Notification marked as read'
+    };
   });
-  
+
   // Mark all notifications as read
   fastify.patch('/read-all', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // In a real app, you would update your database
-      return {
-        success: true,
-        message: 'All notifications marked as read'
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would update your database
+    return {
+      success: true,
+      message: 'All notifications marked as read'
+    };
   });
-  
+
   // Create a new notification (typically called by system processes)
   fastify.post('/', async (request, reply) => {
     // This would typically be an admin or system operation
@@ -132,30 +117,25 @@ const notificationsRoutes: FastifyPluginAsync = async (fastify) => {
     if (!title || !message || !type || !recipientId) {
       return reply.code(400).send({ error: 'Missing required fields' });
     }
-    
-    try {
-      // In a real app, you would save to your database
-      const newNotification = {
-        id: Math.random().toString(36).substring(2, 11),
-        title,
-        message,
-        timestamp: new Date().toISOString(),
-        type,
-        read: false,
-        userId: recipientId
-      };
-      
-      // In a real app, you would emit a socket event here
-      
-      return {
-        success: true,
-        message: 'Notification created successfully',
-        data: newNotification
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would save to your database
+    const newNotification = {
+      id: Math.random().toString(36).substring(2, 11),
+      title,
+      message,
+      timestamp: new Date().toISOString(),
+      type,
+      read: false,
+      userId: recipientId
+    };
+
+    // In a real app, you would emit a socket event here
+
+    return {
+      success: true,
+      message: 'Notification created successfully',
+      data: newNotification
+    };
   });
 };
 

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -15,93 +15,78 @@ const settingsRoutes: FastifyPluginAsync = async (fastify) => {
   // Get user settings
   fastify.get('/', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // In a real app, you would fetch from your database
-      const settings: UserSettings = {
-        id: '1',
-        userId,
-        emailNotifications: true,
-        smsNotifications: true,
-        pushNotifications: false,
-        language: 'English',
-        timezone: 'America/New_York'
-      };
-      
-      return settings;
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would fetch from your database
+    const settings: UserSettings = {
+      id: '1',
+      userId,
+      emailNotifications: true,
+      smsNotifications: true,
+      pushNotifications: false,
+      language: 'English',
+      timezone: 'America/New_York'
+    };
+
+    return settings;
   });
-  
+
   // Update user settings
   fastify.patch('/', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
+
     const updates = request.body as Partial<UserSettings>;
-    
-    try {
-      // In a real app, you would update your database
-      // For demo purposes, we'll return the updated settings
-      const updatedSettings: UserSettings = {
-        id: '1',
-        userId,
-        emailNotifications: updates.emailNotifications ?? true,
-        smsNotifications: updates.smsNotifications ?? true,
-        pushNotifications: updates.pushNotifications ?? false,
-        language: updates.language ?? 'English',
-        timezone: updates.timezone ?? 'America/New_York'
-      };
-      
-      return {
-        success: true,
-        message: 'Settings updated successfully',
-        data: updatedSettings
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would update your database
+    // For demo purposes, we'll return the updated settings
+    const updatedSettings: UserSettings = {
+      id: '1',
+      userId,
+      emailNotifications: updates.emailNotifications ?? true,
+      smsNotifications: updates.smsNotifications ?? true,
+      pushNotifications: updates.pushNotifications ?? false,
+      language: updates.language ?? 'English',
+      timezone: updates.timezone ?? 'America/New_York'
+    };
+
+    return {
+      success: true,
+      message: 'Settings updated successfully',
+      data: updatedSettings
+    };
   });
-  
+
   // Reset user settings to defaults
   fastify.post('/reset', async (request, reply) => {
     const { userId } = getAuth(request);
-    
+
     if (!userId) {
       return reply.code(401).send({ error: 'Unauthorized' });
     }
-    
-    try {
-      // In a real app, you would reset settings in your database
-      const defaultSettings: UserSettings = {
-        id: '1',
-        userId,
-        emailNotifications: true,
-        smsNotifications: false,
-        pushNotifications: false,
-        language: 'English',
-        timezone: 'UTC'
-      };
-      
-      return {
-        success: true,
-        message: 'Settings reset to defaults',
-        data: defaultSettings
-      };
-    } catch (error) {
-      fastify.log.error(error);
-      return reply.code(500).send({ error: 'Internal Server Error' });
-    }
+
+    // In a real app, you would reset settings in your database
+    const defaultSettings: UserSettings = {
+      id: '1',
+      userId,
+      emailNotifications: true,
+      smsNotifications: false,
+      pushNotifications: false,
+      language: 'English',
+      timezone: 'UTC'
+    };
+
+    return {
+      success: true,
+      message: 'Settings reset to defaults',
+      data: defaultSettings
+    };
   });
 };
 

--- a/frontend/src/components/TranslatedText.test.tsx
+++ b/frontend/src/components/TranslatedText.test.tsx
@@ -1,13 +1,19 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+
+const mocks = vi.hoisted(() => ({
+  language: 'en-US',
+  translateText: vi.fn(async (text: string) => text),
+  getSpanishTranslation: vi.fn((text: string) => text),
+}));
 
 vi.mock('../contexts/LingoTranslationContext', () => ({
   useLingoTranslation: vi.fn(() => ({
-    language: 'en-US',
+    language: mocks.language,
     setLanguage: vi.fn(),
     isTranslating: false,
-    translateText: vi.fn(async (t: string) => t),
+    translateText: mocks.translateText,
     preloadingComplete: true,
     isInitialized: true,
     isProviderMounted: true,
@@ -15,14 +21,21 @@ vi.mock('../contexts/LingoTranslationContext', () => ({
   LingoTranslationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-// Mock SpanishTranslations to return unchanged text (no local translation)
 vi.mock('../services/SpanishTranslations', () => ({
-  getSpanishTranslation: vi.fn((text: string) => text),
+  getSpanishTranslation: mocks.getSpanishTranslation,
 }));
 
 import TranslatedText from './TranslatedText';
 
 describe('TranslatedText', () => {
+  beforeEach(() => {
+    mocks.language = 'en-US';
+    mocks.translateText.mockReset();
+    mocks.translateText.mockImplementation(async (text: string) => text);
+    mocks.getSpanishTranslation.mockReset();
+    mocks.getSpanishTranslation.mockImplementation((text: string) => text);
+  });
+
   it('renders children as text', () => {
     render(<TranslatedText>Hello World</TranslatedText>);
     expect(screen.getByText('Hello World')).toBeInTheDocument();
@@ -65,5 +78,68 @@ describe('TranslatedText', () => {
       <TranslatedText element="div">Div text</TranslatedText>
     );
     expect(container.querySelector('div')?.textContent).toBe('Div text');
+  });
+
+  it('uses the immediate Spanish dictionary result when available', () => {
+    mocks.language = 'es-ES';
+    mocks.getSpanishTranslation.mockImplementation((text: string) => text === 'Home' ? 'Inicio' : text);
+
+    render(<TranslatedText>Home</TranslatedText>);
+
+    expect(screen.getByText('Inicio')).toBeInTheDocument();
+    expect(mocks.translateText).not.toHaveBeenCalled();
+  });
+
+  it('skips translation for very short strings', async () => {
+    mocks.language = 'es-ES';
+
+    render(<TranslatedText>A</TranslatedText>);
+
+    await waitFor(() => expect(screen.getByText('A')).toBeInTheDocument());
+    expect(mocks.translateText).not.toHaveBeenCalled();
+  });
+
+  it('renders the async translation result when no dictionary entry exists', async () => {
+    mocks.language = 'es-ES';
+    mocks.translateText.mockResolvedValueOnce('Bonjour');
+
+    render(<TranslatedText>Hello</TranslatedText>);
+
+    await waitFor(() => expect(screen.getByText('Bonjour')).toBeInTheDocument());
+    expect(mocks.translateText).toHaveBeenCalledWith('Hello');
+  });
+
+  it('falls back to the provided fallback text when translation fails', async () => {
+    mocks.language = 'es-ES';
+    mocks.translateText.mockRejectedValueOnce(new Error('boom'));
+
+    render(<TranslatedText fallback="Respaldo">Missing</TranslatedText>);
+
+    await waitFor(() => expect(screen.getByText('Respaldo')).toBeInTheDocument());
+  });
+
+  it('shows the loader wrapper while an async translation is pending', async () => {
+    mocks.language = 'es-ES';
+    let resolveTranslation: (value: string) => void = () => undefined;
+    const pendingTranslation = new Promise<string>((resolve) => {
+      resolveTranslation = resolve;
+    });
+    mocks.translateText.mockReturnValueOnce(pendingTranslation);
+
+    const { container } = render(
+      <TranslatedText showLoader>Hello</TranslatedText>
+    );
+
+    await waitFor(() => expect(container.querySelector('.opacity-60')).toBeInTheDocument());
+
+    resolveTranslation('Hola');
+
+    await waitFor(() => expect(screen.getByText('Hola')).toBeInTheDocument());
+  });
+
+  it('renders the fallback when the translated text and children are empty', async () => {
+    render(<TranslatedText fallback="Fallback text"></TranslatedText>);
+
+    await waitFor(() => expect(screen.getByText('Fallback text')).toBeInTheDocument());
   });
 });

--- a/frontend/src/components/layout/ModernSidebar.test.tsx
+++ b/frontend/src/components/layout/ModernSidebar.test.tsx
@@ -1,14 +1,56 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+
+type Role = 'student' | 'parent' | 'teacher' | 'administrator';
+
+const mocks = vi.hoisted(() => {
+  const MockIcon = () => null;
+
+  return {
+    pathname: '/home',
+    signOut: vi.fn(),
+    user: {
+      id: 'u1',
+      imageUrl: '',
+      firstName: 'Test',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
+    },
+    menuItems: [
+      {
+        name: 'Home',
+        icon: MockIcon,
+        children: [
+          { name: 'Dashboard', href: '/dashboard', icon: MockIcon },
+          {
+            name: 'Group',
+            icon: MockIcon,
+            children: [
+              { name: 'Nested Link', href: '/nested', icon: MockIcon },
+              { name: 'Nested Label', icon: MockIcon },
+            ],
+          },
+          { name: 'Placeholder', icon: MockIcon },
+        ],
+      },
+      {
+        name: 'Direct Item',
+        href: '/direct',
+        icon: MockIcon,
+      },
+    ] as Array<Record<string, unknown>>,
+  };
+});
 
 vi.mock('../../contexts/LingoTranslationContext', () => ({
   useLingoTranslation: vi.fn(() => ({
     language: 'en-US',
     setLanguage: vi.fn(),
     isTranslating: false,
-    translateText: vi.fn(async (t: string) => t),
+    translateText: vi.fn(async (text: string) => text),
     preloadingComplete: true,
     isInitialized: true,
     isProviderMounted: true,
@@ -20,27 +62,22 @@ vi.mock('../../services/SpanishTranslations', () => ({
   getSpanishTranslation: vi.fn((text: string) => text),
 }));
 
-const mockSignOut = vi.fn();
+vi.mock('../../config/menuConfig', () => ({
+  getMenuItems: vi.fn(() => mocks.menuItems),
+}));
 
 vi.mock('@clerk/clerk-react', () => ({
   useUser: vi.fn(() => ({
-    user: {
-      id: 'u1',
-      imageUrl: '',
-      firstName: 'Test',
-      lastName: 'User',
-      primaryEmailAddress: { emailAddress: 'test@example.com' },
-      emailAddresses: [{ emailAddress: 'test@example.com' }],
-    },
+    user: mocks.user,
   })),
-  useClerk: vi.fn(() => ({ signOut: mockSignOut })),
+  useClerk: vi.fn(() => ({ signOut: mocks.signOut })),
 }));
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
   return {
     ...actual,
-    useLocation: vi.fn(() => ({ pathname: '/home' })),
+    useLocation: vi.fn(() => ({ pathname: mocks.pathname })),
     Link: ({ children, to, ...rest }: { children: React.ReactNode; to: string; className?: string }) => (
       <a href={to} {...rest}>
         {children}
@@ -50,84 +87,167 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 import ModernSidebar from './ModernSidebar';
-import type { Role } from '../../config/menuConfig';
 
 const defaultProps = {
   userRoles: ['teacher'] as Role[],
 };
 
+const renderSidebar = (props?: Partial<React.ComponentProps<typeof ModernSidebar>>) =>
+  render(
+    <MemoryRouter>
+      <ModernSidebar {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+
 describe('ModernSidebar', () => {
+  beforeEach(() => {
+    mocks.pathname = '/home';
+    mocks.signOut.mockReset();
+    mocks.user = {
+      id: 'u1',
+      imageUrl: '',
+      firstName: 'Test',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
+    };
+    mocks.menuItems = [
+      {
+        name: 'Home',
+        icon: (() => null) as () => null,
+        children: [
+          { name: 'Dashboard', href: '/dashboard', icon: (() => null) as () => null },
+          {
+            name: 'Group',
+            icon: (() => null) as () => null,
+            children: [
+              { name: 'Nested Link', href: '/nested', icon: (() => null) as () => null },
+              { name: 'Nested Label', icon: (() => null) as () => null },
+            ],
+          },
+          { name: 'Placeholder', icon: (() => null) as () => null },
+        ],
+      },
+      {
+        name: 'Direct Item',
+        href: '/direct',
+        icon: (() => null) as () => null,
+      },
+    ];
+  });
+
   it('renders without crashing for teacher role', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar {...defaultProps} />
-      </MemoryRouter>
-    );
+    renderSidebar();
     expect(document.body).toBeTruthy();
   });
 
-  it('renders without crashing for admin role', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar userRoles={['administrator'] as Role[]} />
-      </MemoryRouter>
-    );
+  it('renders without crashing for other role combinations', () => {
+    renderSidebar({ userRoles: ['administrator'] as Role[] });
+    renderSidebar({ userRoles: ['parent'] as Role[] });
+    renderSidebar({ userRoles: ['student'] as Role[] });
+    renderSidebar({ userRoles: [] });
     expect(document.body).toBeTruthy();
   });
 
-  it('renders without crashing for parent role', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar userRoles={['parent'] as Role[]} />
-      </MemoryRouter>
-    );
-    expect(document.body).toBeTruthy();
-  });
+  it('renders the sign out button and calls signOut when clicked', () => {
+    renderSidebar();
 
-  it('renders without crashing for student role', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar userRoles={['student'] as Role[]} />
-      </MemoryRouter>
-    );
-    expect(document.body).toBeTruthy();
-  });
-
-  it('renders without crashing with no roles', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar userRoles={[]} />
-      </MemoryRouter>
-    );
-    expect(document.body).toBeTruthy();
-  });
-
-  it('renders the Sign Out button', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar {...defaultProps} />
-      </MemoryRouter>
-    );
-    // Sign Out button is in the sidebar
-    expect(screen.getByText('Sign Out')).toBeInTheDocument();
-  });
-
-  it('calls signOut when sign out button is clicked', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar {...defaultProps} />
-      </MemoryRouter>
-    );
     fireEvent.click(screen.getByText('Sign Out'));
-    expect(mockSignOut).toHaveBeenCalled();
+
+    expect(mocks.signOut).toHaveBeenCalled();
   });
 
   it('renders the Raices brand link', () => {
-    render(
-      <MemoryRouter>
-        <ModernSidebar {...defaultProps} />
-      </MemoryRouter>
-    );
+    renderSidebar();
     expect(screen.getByText('Raíces')).toBeInTheDocument();
+  });
+
+  it('auto-expands nested menus for the active route', async () => {
+    mocks.pathname = '/nested';
+
+    renderSidebar();
+
+    await waitFor(() => expect(screen.getByText('Nested Link')).toBeInTheDocument());
+    expect(screen.getByText('Nested Label')).toBeInTheDocument();
+  });
+
+  it('toggles top-level and nested menus when clicked', async () => {
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Home' }));
+    expect(await screen.findByText('Dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('Nested Link')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Group' }));
+    expect(await screen.findByText('Nested Link')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Group' }));
+    await waitFor(() => expect(screen.queryByText('Nested Link')).not.toBeInTheDocument());
+  });
+
+  it('renders placeholder child items without links', async () => {
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Home' }));
+
+    const placeholder = await screen.findByText('Placeholder');
+    expect(placeholder.closest('a')).toBeNull();
+  });
+
+  it('marks direct links as active when the route matches', () => {
+    mocks.pathname = '/direct';
+
+    renderSidebar();
+
+    expect(screen.getByRole('link', { name: 'Direct Item' }).className).toContain('bg-red-500/20');
+  });
+
+  it('updates the mobile state on hover', () => {
+    const { container } = renderSidebar();
+    const sidebar = container.firstElementChild as HTMLElement;
+
+    fireEvent.mouseEnter(sidebar);
+    expect(sidebar.className).toContain('w-72');
+
+    fireEvent.mouseLeave(sidebar);
+    expect(sidebar.className).toContain('w-16');
+  });
+
+  it('renders the user avatar image when one exists', () => {
+    mocks.user = {
+      ...mocks.user,
+      imageUrl: 'https://example.com/avatar.png',
+    };
+
+    renderSidebar();
+
+    expect(screen.getByAltText('Test User')).toBeInTheDocument();
+  });
+
+  it('falls back to the email initial and translated user label when profile details are missing', () => {
+    mocks.user = {
+      id: 'u2',
+      imageUrl: '',
+      firstName: '',
+      lastName: '',
+      primaryEmailAddress: { emailAddress: 'alpha@example.com' },
+      emailAddresses: [{ emailAddress: 'alpha@example.com' }],
+    };
+
+    renderSidebar();
+
+    expect(screen.getByText('a')).toBeInTheDocument();
+    const profileSection = screen.getByText('alpha@example.com').closest('div');
+    if (!profileSection) {
+      throw new Error('Expected profile section');
+    }
+    expect(within(profileSection.parentElement as HTMLElement).getByText('User')).toBeInTheDocument();
+  });
+
+  it('removes the bottom border when hideBottomBorder is enabled', () => {
+    const { container } = renderSidebar({ hideBottomBorder: true });
+    const footer = container.querySelector('button')?.closest('div')?.parentElement;
+
+    expect(footer?.className).not.toContain('border-t');
   });
 });

--- a/frontend/src/contexts/LingoTranslationContext.test.tsx
+++ b/frontend/src/contexts/LingoTranslationContext.test.tsx
@@ -2,12 +2,18 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 
+const mocks = vi.hoisted(() => ({
+  translateText: vi.fn(async (text: string) => `[es]${text}`),
+  clearCache: vi.fn(),
+  preloadCommonTranslations: vi.fn(async () => {}),
+}));
+
 // Mock the service BEFORE importing the context
 vi.mock('../services/LingoTranslationService', () => ({
   lingoTranslationService: {
-    translateText: vi.fn(async (t: string) => `[es]${t}`),
-    clearCache: vi.fn(),
-    preloadCommonTranslations: vi.fn(async () => {}),
+    translateText: mocks.translateText,
+    clearCache: mocks.clearCache,
+    preloadCommonTranslations: mocks.preloadCommonTranslations,
     getStats: vi.fn(() => ({ cacheSize: 0, localTranslationsCount: 0 })),
   },
 }));
@@ -16,16 +22,37 @@ import { LingoTranslationProvider, useLingoTranslation } from './LingoTranslatio
 
 const TestConsumer = () => {
   const ctx = useLingoTranslation();
+  const [translated, setTranslated] = React.useState('');
+
   return (
     <div>
       <span data-testid="lang">{ctx.language}</span>
       <span data-testid="initialized">{String(ctx.isInitialized)}</span>
       <span data-testid="preloaded">{String(ctx.preloadingComplete)}</span>
+      <span data-testid="translated">{translated}</span>
       <button
         data-testid="switch-es"
         onClick={() => ctx.setLanguage('es-ES')}
       >
         to-es
+      </button>
+      <button
+        data-testid="switch-invalid"
+        onClick={() => ctx.setLanguage('fr-FR' as never)}
+      >
+        invalid
+      </button>
+      <button
+        data-testid="translate-empty"
+        onClick={async () => setTranslated(await ctx.translateText(''))}
+      >
+        empty
+      </button>
+      <button
+        data-testid="translate-hello"
+        onClick={async () => setTranslated(await ctx.translateText('Hello'))}
+      >
+        hello
       </button>
     </div>
   );
@@ -50,6 +77,11 @@ const renderProvider = async (language?: string) => {
 describe('LingoTranslationProvider', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    mocks.translateText.mockReset();
+    mocks.translateText.mockImplementation(async (text: string) => `[es]${text}`);
+    mocks.clearCache.mockReset();
+    mocks.preloadCommonTranslations.mockReset();
+    mocks.preloadCommonTranslations.mockImplementation(async () => {});
   });
 
   it('initializes with en-US by default', async () => {
@@ -61,8 +93,7 @@ describe('LingoTranslationProvider', () => {
   it('reads selectedLanguage from localStorage', async () => {
     await renderProvider('es-ES');
     await waitFor(() => expect(screen.getByTestId('initialized').textContent).toBe('true'), { timeout: 2000 });
-    // Language may be es-ES or en-US depending on init logic
-    expect(['en-US', 'es-ES']).toContain(screen.getByTestId('lang').textContent);
+    expect(screen.getByTestId('lang').textContent).toBe('es-ES');
   });
 
   it('reads authSelectedLanguage from localStorage and removes it', async () => {
@@ -94,6 +125,62 @@ describe('LingoTranslationProvider', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'languageChanged' })
     );
+    expect(window.localStorage.getItem('selectedLanguage')).toBe('es-ES');
+  });
+
+  it('ignores invalid external language change events', async () => {
+    await renderProvider();
+    await waitFor(() => expect(screen.getByTestId('initialized').textContent).toBe('true'), { timeout: 2000 });
+
+    window.dispatchEvent(new CustomEvent('languageChanged', { detail: { language: 'fr-FR' } }));
+
+    await waitFor(() => expect(screen.getByTestId('lang').textContent).toBe('en-US'), { timeout: 2000 });
+  });
+
+  it('ignores invalid manual language changes', async () => {
+    await renderProvider();
+    fireEvent.click(screen.getByTestId('switch-invalid'));
+    expect(screen.getByTestId('lang').textContent).toBe('en-US');
+  });
+
+  it('preloads translations when the initial language is Spanish', async () => {
+    await renderProvider('es-ES');
+
+    await waitFor(() => expect(screen.getByTestId('preloaded').textContent).toBe('true'), { timeout: 2000 });
+    expect(mocks.clearCache).toHaveBeenCalled();
+    expect(mocks.preloadCommonTranslations).toHaveBeenCalledWith('es-ES');
+  });
+
+  it('returns an empty string for falsy translateText input', async () => {
+    await renderProvider();
+    fireEvent.click(screen.getByTestId('translate-empty'));
+
+    await waitFor(() => expect(screen.getByTestId('translated').textContent).toBe(''));
+    expect(mocks.translateText).not.toHaveBeenCalled();
+  });
+
+  it('returns the original text for English translations', async () => {
+    await renderProvider();
+    fireEvent.click(screen.getByTestId('translate-hello'));
+
+    await waitFor(() => expect(screen.getByTestId('translated').textContent).toBe('Hello'));
+    expect(mocks.translateText).not.toHaveBeenCalled();
+  });
+
+  it('uses the translation service for Spanish translations', async () => {
+    await renderProvider('es-ES');
+    fireEvent.click(screen.getByTestId('translate-hello'));
+
+    await waitFor(() => expect(screen.getByTestId('translated').textContent).toBe('[es]Hello'));
+    expect(mocks.translateText).toHaveBeenCalledWith('Hello', 'es-ES');
+  });
+
+  it('falls back to the original text when the translation service throws', async () => {
+    mocks.translateText.mockRejectedValueOnce(new Error('boom'));
+    await renderProvider('es-ES');
+    fireEvent.click(screen.getByTestId('translate-hello'));
+
+    await waitFor(() => expect(screen.getByTestId('translated').textContent).toBe('Hello'));
   });
 });
 

--- a/frontend/src/hooks/useClerkLocalization.test.ts
+++ b/frontend/src/hooks/useClerkLocalization.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
+let mockLanguage = 'es-ES';
+
 vi.mock('../contexts/LingoTranslationContext', () => ({
   useLingoTranslation: vi.fn(() => ({
-    language: 'es-ES',
+    language: mockLanguage,
     setLanguage: vi.fn(),
     isTranslating: false,
     translateText: vi.fn(async (t: string) => `[es]${t}`),
@@ -19,12 +21,15 @@ describe('useClerkLocalization', () => {
   let container: HTMLDivElement;
 
   beforeEach(() => {
+    mockLanguage = 'es-ES';
     vi.useFakeTimers();
     container = document.createElement('div');
     container.className = 'clerk-auth-madrid';
     container.innerHTML = `
-      <div class="cl-headerTitle">Sign in to roots</div>
-      <div class="cl-headerSubtitle">to continue to roots</div>
+      <div class="cl-card">
+        <div class="cl-headerTitle">Sign in</div>
+        <div class="cl-headerSubtitle">to continue to roots</div>
+      </div>
     `;
     document.body.appendChild(container);
   });
@@ -35,9 +40,53 @@ describe('useClerkLocalization', () => {
   });
 
   it('replaces Clerk text content when language is es-ES without throwing', async () => {
-    // Should run without errors; the hook mutates DOM
     expect(() => renderHook(() => useClerkLocalization())).not.toThrow();
     await act(async () => { vi.advanceTimersByTime(300); });
+    expect(container.querySelector('.cl-headerTitle')?.textContent).toBe('Iniciar sesión');
+    expect(container.querySelector('.cl-headerSubtitle')?.textContent).toBe('to continue to Raíces');
+  });
+
+  it('reverses translated text when the language is en-US', async () => {
+    mockLanguage = 'en-US';
+    container.innerHTML = `
+      <div class="cl-card">
+        <div class="cl-headerTitle">Iniciar sesión</div>
+        <div class="cl-headerSubtitle">para ir a Raíces</div>
+      </div>
+    `;
+
+    renderHook(() => useClerkLocalization());
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    expect(container.querySelector('.cl-headerTitle')?.textContent).toBe('Sign in');
+    expect(container.querySelector('.cl-headerSubtitle')?.textContent).toBe('to continue to Raíces');
+  });
+
+  it('translates forgot password links when auth is stable', async () => {
+    container.innerHTML = `
+      <div class="cl-card">
+        <a href="/forgot-password">Forgot password?</a>
+      </div>
+    `;
+
+    renderHook(() => useClerkLocalization());
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    expect(container.querySelector('a')?.textContent).toBe('¿Olvidaste tu contraseña?');
+  });
+
+  it('skips translation while an auth action is in progress', async () => {
+    container.innerHTML = `
+      <div class="cl-card">
+        <button disabled>Signing in</button>
+        <div class="cl-headerTitle">Sign in</div>
+      </div>
+    `;
+
+    renderHook(() => useClerkLocalization());
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    expect(container.querySelector('.cl-headerTitle')?.textContent).toBe('Sign in');
   });
 
   it('cleans up observer and interval on unmount', () => {
@@ -59,5 +108,41 @@ describe('useClerkLocalization', () => {
     const observeSpy = vi.spyOn(MutationObserver.prototype, 'observe');
     renderHook(() => useClerkLocalization());
     expect(observeSpy).toHaveBeenCalled();
+  });
+
+  it('re-translates newly added Clerk content after a mutation', async () => {
+    renderHook(() => useClerkLocalization());
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    const newNode = document.createElement('div');
+    newNode.className = 'cl-footerActionText';
+    newNode.textContent = 'No account?';
+    container.appendChild(newNode);
+
+    await act(async () => {
+      await Promise.resolve();
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(newNode.textContent).toBe('¿No tienes cuenta?');
+  });
+
+  it('retries translation during the periodic interval when auth is idle', async () => {
+    renderHook(() => useClerkLocalization());
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    const title = container.querySelector('.cl-headerTitle');
+    if (!title) {
+      throw new Error('Expected header title');
+    }
+
+    title.textContent = 'Sign in';
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(title.textContent).toBe('Iniciar sesión');
   });
 });

--- a/frontend/src/services/LingoTranslationService.test.ts
+++ b/frontend/src/services/LingoTranslationService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The service is a singleton module. We use vi.resetModules() + vi.doMock() +
 // dynamic import() per test so each test gets a fresh module instance.
@@ -10,11 +10,21 @@ describe('LingoTranslationService', () => {
     vi.resetModules();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   const buildMockEngine = () => ({
     localizeText: vi.fn(async (t: string) => `[es]${t}`),
     localizeObject: vi.fn(async (o: unknown) => o),
     localizeHtml: vi.fn(async (h: string) => h),
   });
+
+  const stubHostname = (hostname: string) => {
+    vi.stubGlobal('window', {
+      location: { hostname },
+    } as unknown as Window & typeof globalThis);
+  };
 
   const loadService = async (engine?: ReturnType<typeof buildMockEngine>) => {
     const e = engine ?? buildMockEngine();
@@ -99,6 +109,27 @@ describe('LingoTranslationService', () => {
       // Engine called at most once (0 in localhost)
       expect(mockEngine.localizeText.mock.calls.length).toBeLessThanOrEqual(1);
     });
+
+    it('uses the SDK and caches results away from localhost', async () => {
+      stubHostname('app.example.com');
+      const mockEngine = buildMockEngine();
+      const { svc } = await loadService(mockEngine);
+
+      await expect(svc.translateText('Bonjour', 'fr-FR')).resolves.toBe('[es]Bonjour');
+      await expect(svc.translateText('Bonjour', 'fr-FR')).resolves.toBe('[es]Bonjour');
+
+      expect(mockEngine.localizeText).toHaveBeenCalledTimes(1);
+      expect(svc.getStats().cacheSize).toBe(1);
+    });
+
+    it('falls back to the original text when the SDK throws', async () => {
+      stubHostname('app.example.com');
+      const mockEngine = buildMockEngine();
+      mockEngine.localizeText.mockRejectedValueOnce(new Error('boom'));
+      const { svc } = await loadService(mockEngine);
+
+      await expect(svc.translateText('Needs translation', 'fr-FR')).resolves.toBe('Needs translation');
+    });
   });
 
   describe('clearCache / getStats', () => {
@@ -132,6 +163,103 @@ describe('LingoTranslationService', () => {
       svc.clearCache();
       expect(svc.getStats().cacheSize).toBe(0);
       expect(svc.getStats().cacheSize).toBeGreaterThanOrEqual(before >= 0 ? 0 : 0);
+    });
+  });
+
+  describe('translateObject', () => {
+    it('returns the original object for English', async () => {
+      const { svc } = await loadService();
+      const input = { title: 'Hello', nested: { message: 'World' } };
+      await expect(svc.translateObject(input, 'en-US')).resolves.toBe(input);
+    });
+
+    it('recursively translates Spanish objects using translateText', async () => {
+      const { svc } = await loadService();
+      const input = {
+        title: 'Home',
+        nested: {
+          action: 'Settings',
+          count: 3,
+        },
+      };
+
+      await expect(svc.translateObject(input, 'es-ES')).resolves.toEqual({
+        title: 'Inicio',
+        nested: {
+          action: 'Configuración',
+          count: 3,
+        },
+      });
+    });
+
+    it('uses the SDK for non-Spanish object translation', async () => {
+      const mockEngine = buildMockEngine();
+      mockEngine.localizeObject.mockResolvedValueOnce({ title: '[fr]Bonjour' });
+      const { svc } = await loadService(mockEngine);
+
+      await expect(svc.translateObject({ title: 'Hello' }, 'fr-FR')).resolves.toEqual({ title: '[fr]Bonjour' });
+      expect(mockEngine.localizeObject).toHaveBeenCalledWith(
+        { title: 'Hello' },
+        expect.objectContaining({ sourceLocale: 'en-US', targetLocale: 'fr-FR' })
+      );
+    });
+
+    it('falls back to the original object when object translation fails', async () => {
+      const mockEngine = buildMockEngine();
+      mockEngine.localizeObject.mockRejectedValueOnce(new Error('boom'));
+      const { svc } = await loadService(mockEngine);
+      const input = { title: 'Hello' };
+
+      await expect(svc.translateObject(input, 'fr-FR')).resolves.toBe(input);
+    });
+  });
+
+  describe('translateHtml', () => {
+    it('returns the original html for English', async () => {
+      const { svc } = await loadService();
+      await expect(svc.translateHtml('<p>Hello</p>', 'en-US')).resolves.toBe('<p>Hello</p>');
+    });
+
+    it('uses the SDK for non-English html', async () => {
+      const mockEngine = buildMockEngine();
+      mockEngine.localizeHtml.mockResolvedValueOnce('<p>Bonjour</p>');
+      const { svc } = await loadService(mockEngine);
+
+      await expect(svc.translateHtml('<p>Hello</p>', 'fr-FR')).resolves.toBe('<p>Bonjour</p>');
+      expect(mockEngine.localizeHtml).toHaveBeenCalledWith(
+        '<p>Hello</p>',
+        expect.objectContaining({ sourceLocale: 'en-US', targetLocale: 'fr-FR' })
+      );
+    });
+
+    it('falls back to the original html when html translation fails', async () => {
+      const mockEngine = buildMockEngine();
+      mockEngine.localizeHtml.mockRejectedValueOnce(new Error('boom'));
+      const { svc } = await loadService(mockEngine);
+
+      await expect(svc.translateHtml('<p>Hello</p>', 'fr-FR')).resolves.toBe('<p>Hello</p>');
+    });
+  });
+
+  describe('preloadCommonTranslations', () => {
+    it('preloads the common Spanish phrases', async () => {
+      const { svc } = await loadService();
+      const translateSpy = vi.spyOn(svc, 'translateText');
+
+      await svc.preloadCommonTranslations('es-ES');
+
+      expect(translateSpy).toHaveBeenCalledTimes(11);
+      expect(translateSpy).toHaveBeenCalledWith('Home', 'es-ES');
+      expect(translateSpy).toHaveBeenCalledWith('Search', 'es-ES');
+    });
+
+    it('does nothing for non-Spanish preload requests', async () => {
+      const { svc } = await loadService();
+      const translateSpy = vi.spyOn(svc, 'translateText');
+
+      await svc.preloadCommonTranslations('fr-FR');
+
+      expect(translateSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand the translation and layout test suite so the low-covered frontend paths are actually exercised
- simplify dead backend route wrappers and add server tests for webhook error handling
- lift the repo's local combined unit-test line coverage from about 77.5% to about 92.0%

## Verification
- npm test
- npm run lint
- npm run build
- cd frontend && npm run test:coverage
- cd backend && npm run test:coverage