### PR TITLE
fix(ci): pin patched clerk shared dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
-      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
+      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/@clerk/fastify/node_modules/@clerk/shared": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
-      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
+      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8515,9 +8515,9 @@
       }
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.3",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
-      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
+      "version": "3.47.4",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.4.tgz",
+      "integrity": "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "@vercel/static-config": {
       "ajv": "8.18.0"
     },
+    "@clerk/clerk-react": {
+      "@clerk/shared": "3.47.4"
+    },
     "@lingo.dev/_react": {
       "next": "15.5.15",
       "lodash": "4.18.1"


### PR DESCRIPTION
## Summary
- pin the frontend Clerk shared package to the patched 3.47.4 release via npm overrides
- refresh the root lockfile so Security Audit resolves the vulnerable frontend path
- keep the fix minimal and scoped to the failing workflow

## Verification
- npm audit --workspace=frontend --audit-level=high --omit=dev
- npm test
- npm run lint
- npm run build