### PR TITLE
fix(ci): patch Clerk security audit

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@clerk/fastify": "^3.1.15",
+    "@clerk/fastify": "^3.1.22",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@supabase/supabase-js": "^2.103.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@clerk/clerk-react": "^5.61.5",
+    "@clerk/clerk-react": "^5.61.6",
     "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.0",
     "framer-motion": "^12.34.1",

--- a/frontend/src/services/GitHubContributorsService.ts
+++ b/frontend/src/services/GitHubContributorsService.ts
@@ -11,7 +11,7 @@ export interface ContributorStats {
   timelineData: TimelineItem[];
 }
 
-export interface TimelineItem {
+interface TimelineItem {
   date: string;
   title: string;
   description: string;
@@ -226,4 +226,4 @@ export class GitHubContributorsService {
   static addContributor(email: string, stats: ContributorStats): void {
     GITHUB_CONTRIBUTORS[email] = stats;
   }
-} 
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clerk/fastify": "^3.1.15",
+        "@clerk/fastify": "^3.1.22",
         "@fastify/cors": "^11.2.0",
         "@fastify/rate-limit": "^10.3.0",
         "@supabase/supabase-js": "^2.103.3",
@@ -237,7 +237,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clerk/clerk-react": "^5.61.5",
+        "@clerk/clerk-react": "^5.61.6",
         "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.0",
         "framer-motion": "^12.34.1",
@@ -1307,12 +1307,12 @@
       "license": "(Apache-2.0 WITH LLVM-exception)"
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.13",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.13.tgz",
-      "integrity": "sha512-E4ir94gs9Cxh+v20SGVLXblb0coVUd2La5o1Lmz7olNOBimMEsZ7T6MpGFNJveEH1sQ+HhSf1a1uLm9pMiK/tg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.4.tgz",
+      "integrity": "sha512-EGdpxBG1joIYzRBtpzTq2FGyM2ErSSF2UB7FZXrHiSb6V/uRUcvVcX7IWvYeEyg1AG100gJWr0KpbutajVCLMA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.8.2",
+        "@clerk/shared": "^4.9.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -1321,13 +1321,13 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
-      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.9.0.tgz",
+      "integrity": "sha512-YU9Fv6FK1EwxM7uz1hGPrLpvcHRhHm8Quuh5RL343oXakE+/JHtYy4OhwVgqYVA+j63pw+7lpghL3CYQTgk0hA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.16",
+        "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -1350,12 +1350,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.5",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.5.tgz",
-      "integrity": "sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==",
+      "version": "5.61.6",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.6.tgz",
+      "integrity": "sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.4",
+        "@clerk/shared": "^3.47.5",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -1367,15 +1367,15 @@
       }
     },
     "node_modules/@clerk/fastify": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@clerk/fastify/-/fastify-3.1.15.tgz",
-      "integrity": "sha512-y7/AA9IB9kwxLUi/p1Z57/tMyNaooCumagP4lbFve6ip2Vn9W/ZbDQqRwd5gzckhEHmELAPnuHgnmqINGebFFg==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/@clerk/fastify/-/fastify-3.1.22.tgz",
+      "integrity": "sha512-cKtxRRMm5S4k547++tLkkP1G2xSYCBZJpHXBeNmwLytvGMKVX035IlL/Y8aBa6M4NG0t4m1zhVMFbK3V0N81pQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.2.13",
-        "@clerk/shared": "^4.8.2",
+        "@clerk/backend": "^3.4.4",
+        "@clerk/shared": "^4.9.0",
         "cookies": "0.9.1",
-        "fastify-plugin": "^5.0.1"
+        "fastify-plugin": "^5.1.0"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1385,13 +1385,13 @@
       }
     },
     "node_modules/@clerk/fastify/node_modules/@clerk/shared": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
-      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.9.0.tgz",
+      "integrity": "sha512-YU9Fv6FK1EwxM7uz1hGPrLpvcHRhHm8Quuh5RL343oXakE+/JHtYy4OhwVgqYVA+j63pw+7lpghL3CYQTgk0hA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.16",
+        "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.4",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.4.tgz",
-      "integrity": "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==",
+      "version": "3.47.5",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5293,9 +5293,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
-      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
       "license": "MIT",
       "funding": {
         "type": "github",


### PR DESCRIPTION
## Summary
- update frontend Clerk React to 5.61.6
- update backend Clerk Fastify to 3.1.22
- refresh package lock so Clerk shared/backend transitive packages resolve to patched versions

## Verification
- npm audit --workspace=frontend --audit-level=high --omit=dev
- npm audit --workspace=backend --audit-level=high --omit=dev

Note: local npm ci in the temporary worktree hit npm CLI internal error "Exit handler never called" after dependency extraction; the GitHub workflow will run a clean npm ci.