### PR TITLE
fix: resolve CodeQL code-scanning alerts [triage]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-typecheck:
     name: Lint & Typecheck

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 3 * * *' # Daily 3am UTC
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: Secret Scanning

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [develop, main]
 
+permissions:
+  contents: read
+
 jobs:
   knip:
     name: Knip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 9 * * 1' # Monday 9am UTC
 
+permissions:
+  contents: read
+
 jobs:
   npm-audit:
     name: npm audit

--- a/scripts/check-localization.js
+++ b/scripts/check-localization.js
@@ -126,10 +126,13 @@ function checkFile(filePath) {
 
 function getSuggestion(text) {
   // Extract the actual text content
-  let cleanText = text
-    .replace(/<[^>]*>/g, '') // Remove HTML tags
-    .replace(/["']/g, '') // Remove quotes
-    .trim();
+  let cleanText = text;
+  let previous;
+  do {
+    previous = cleanText;
+    cleanText = previous.replace(/<[^>]*>/g, ''); // Remove HTML tags (loop handles nested/overlapping tags)
+  } while (cleanText !== previous);
+  cleanText = cleanText.replace(/["']/g, '').trim(); // Remove quotes
 
   if (cleanText.length < 3) return null;
 


### PR DESCRIPTION
## Summary
- Fix CodeQL high-severity alert (`js/incomplete-multi-character-sanitization`): `getSuggestion()` in `scripts/check-localization.js` now loops HTML-tag stripping until stable, closing the nested/overlapping-tag bypass.
- Fix 8 CodeQL medium-severity alerts (`actions/missing-workflow-permissions`): add explicit `permissions: contents: read` to `ci.yml`, `security.yml`, `gitleaks.yml`, `knip.yml` — none of these workflows write anything, so read-only is least-privilege.

Generated by automated `/triage` run against open GitHub code-scanning alerts (0 Dependabot alerts, 0 open Dependabot PRs, 0 new agent reports this cycle).

## Test plan
- [x] `npm test` (frontend 281 + backend 70, all passing)
- [x] `npx tsc --noEmit` (frontend + backend clean)
- [x] `npm run lint` (clean)
- [x] `npm run check-localization` (0 issues, confirms sanitization fix preserves behavior)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aw8xjLBhjrF9QhXnts5s3z