### PR TITLE
ci: parallelize fail-fast gates (lint, unit-tests, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: lint-typecheck
+    # No `needs:` — lint-typecheck, unit-tests, and build are independent
+    # fail-fast gates. This job does its own checkout + `npm ci` and consumes
+    # no artifact from lint-typecheck, so gating it behind lint-typecheck only
+    # serialized the wall-clock. Run them in parallel instead.
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -67,7 +70,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: unit-tests
+    # No `needs:` — build reads SOURCE, not test output, and downloads no
+    # artifact from unit-tests. Gating it behind unit-tests only serialized the
+    # DAG (lint ⇐ tests ⇐ build ≈ summed wall-clock). Run it in parallel with
+    # the other fail-fast gates; any failure still fails the overall CI run.
     env:
       VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.VITE_CLERK_PUBLISHABLE_KEY || 'pk_test_placeholder' }}
       VITE_BACKEND_URL: http://localhost:3000


### PR DESCRIPTION
Removes two pure-ordering `needs:` gates so the CI fail-fast jobs run in parallel instead of in a fully serialized DAG.

## Problem
`lint-typecheck ⇐ unit-tests ⇐ build` were chained by `needs:`, so their wall-clock times summed (~35s + 48s + 31s ≈ 114s) even though each job is independent — every job does its own `actions/checkout` + `npm ci` and `build` reads **source**, not test output. There is **no `download-artifact`** anywhere in the workflow, so the `needs:` were pure ordering gates, not artifact dependencies.

## Fix
- Remove `needs: lint-typecheck` from `unit-tests`
- Remove `needs: unit-tests` from `build`

All three now run in parallel. A failure in any one still fails the overall run (they are fail-fast gates, not sequential stages). `e2e` keeps `needs: [lint-typecheck]` (PR-only, runs its own build) — unchanged.

## Impact
- Expected wall-clock: **~124s → ~50-55s** (~55% cut)
- No Actions-minutes increase (same total job-seconds, just concurrent)
- Behaviour identical on failure — nothing skipped, same gates enforced

## Validation
- `actionlint .github/workflows/ci.yml` — clean
- `python3 yaml.safe_load` — parses; confirmed all three jobs now `needs=<none>`, `e2e needs=[lint-typecheck]`
- Local pre-push hook: lint + 281 frontend tests + 70 backend tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)