### PR TITLE
fix(deps): fast-uri prod hotfix (host-confusion high)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,5 @@
 {
   "ignore": ["eslint.config.js"],
-  "ignoreDependencies": ["fast-uri"],
   "ignoreBinaries": ["du", "knip", "license-checker", "AGPL-3.0", "playwright"],
   "workspaces": {
     "frontend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       ],
       "devDependencies": {
         "concurrently": "^10.0.3",
-        "fast-uri": "^4.0.0",
         "glob": "^13.0.6",
         "husky": "^9.1.7"
       },
@@ -1760,9 +1759,9 @@
       }
     },
     "node_modules/@fastify/ajv-compiler/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3798,9 +3797,9 @@
       }
     },
     "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4795,9 +4794,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4831,23 +4830,6 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
-    },
-    "node_modules/fast-uri": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.0.0.tgz",
-      "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
       "version": "5.8.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "concurrently": "^10.0.3",
-    "fast-uri": "^4.0.0",
     "glob": "^13.0.6",
     "husky": "^9.1.7"
   },
@@ -58,6 +57,7 @@
     "@rollup/rollup-darwin-x64": "^4.62.0"
   },
   "overrides": {
+    "fast-uri": "3.1.4",
     "undici": ">=7.28.0",
     "esbuild": "0.28.1",
     "fast-xml-parser": "5.5.9",


### PR DESCRIPTION
## Production hotfix: fast-uri host-confusion (HIGH)

Resolves **Dependabot alert #16** on `main` (production). `main` still ships the vulnerable `fast-uri`; this targeted hotfix patches it without pulling the develop backlog.

### Vulnerability
`fast-uri` 3.0.0–3.1.3 — main's sole production vulnerability (1 high), transitive via fastify's ajv/serializer stack at three paths:
- `@fastify/ajv-compiler` → fast-uri
- `ajv` (under `@vercel/static-config`) → fast-uri
- `fast-json-stringify` → fast-uri

Advisories:
- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — host confusion via literal backslash authority delimiter
- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) — host confusion via failed IDN canonicalization

### Fix
- Add root `overrides` entry `"fast-uri": "3.1.4"`.
- Remove the stray, unused root devDep `fast-uri@^4.0.0` (only referenced in knip's `ignoreDependencies`, never imported) — it blocked the blanket override with `EOVERRIDE`.
- Remove `fast-uri` from `knip.json` `ignoreDependencies`.
- Minimal hand-patch of `package-lock.json`: the three nested copies bumped 3.1.2→3.1.4, no sibling churn. `@vitest/coverage-istanbul` + `@istanbuljs/schema` deliberately preserved — a broad `npm audit fix`/full regen prunes them and breaks the frontend `test:coverage` CI job.

Mirrors the proven develop fix `927c179`; main's `package.json`/`knip.json`/`package-lock.json` were byte-identical to that fix's baseline, so the change is the exact same diff. Only `package.json` + `package-lock.json` + `knip.json` touched.

### Verification (reproduced CI against main's baseline)
- `npm ci` (from clean node_modules): succeeds
- `npm audit --omit=dev`: **0 vulnerabilities**
- `npm ls fast-uri --all`: all three paths → `fast-uri@3.1.4 overridden`
- `@vitest/coverage-istanbul` + `@istanbuljs/schema` still present in lockfile
- frontend `test:coverage`: PASS (99.82% stmts)
- backend `test:coverage`: PASS (100% stmts)
- `npm run build`: PASS
- `npm run lint`: PASS

⚠️ Merging deploys to production — **do not merge without human authorization.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZWVt8YGNXeT5pPCTY47Le