### PR TITLE
chore(deps): update tar to 7.5.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6998,9 +6998,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
Moves the remaining compatible update from production-targeting Dependabot PR #220 onto the non-production integration branch. find-my-way 9.7.0 and shell-quote 1.9.0 are already present on develop; this lock-only change updates tar from 7.5.16 to 7.5.22.

Local verification: clean npm ci; lint; 351 unit tests; frontend and backend production builds; localization check.